### PR TITLE
better document language server and package capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,16 @@ Provides syntax highlighting and intellisense for Svelte components in Atom, uti
 
 ## Features
 
+- Syntax highlighting (with TextMate grammar)
+
+Language server feature (that rely on other packages for UI):
+
+- Autocomplete
 - TypeScript support in .svelte components
 - Diagnostic messages for warnings and errors
-- References & definitions provider
+- Datatips
+- References & definitions
+- Code formatting
 
 ## Setup
 
@@ -18,25 +25,42 @@ The default command the plugin uses to run Node is `node`, which will work if th
 
 If no such Node executable can be found by the plugin, then it will fallback on using the Node embedded with Atom. But this will incurs feature loss and/or erratic behaviour of the language server.
 
-### Ensure you have supporting plugins
+### Ensure you have supporting Atom packages
 
-This packages mainly only _exposes_ language features to be consumed by other plugins. It doesn't come with the supporting UI features that are expected to be provided by other "consumer" plugins.
+This package mainly only _exposes_ language features to be consumed by other plugins. It doesn't come with the supporting UI features that are expected to be provided by other "consumer" plugins.
 
-Depending on your tastes, you can try the all inclusive [Atom IDE](https://ide.atom.io/) package, or try to compose for yourself a more personalized experience by hand picking and configuring a bunch of specialized plugins (Atom is all about hacking your IDE after all, isn't it?).
+Initial work on IDE oriented UIs and LSP integration has been done by the [Atom IDE](https://ide.atom.io/) initiative, and all their work was published as the monolithic [atom-ide-ui](https://atom.io/packages/atom-ide-ui) package, but the project has now been retired and is not maintained anymore.
 
-While assuming no endorsement, the following Atom packages have been used with some satisfaction for Svelte development in Atom by some of the authors of this plugin:
+This line of work is now being continued by the atom-community initiative. Their stated objective is to release each UI feature as its own standalone and composable package, but they also offer a meta package that includes all of them: [atom-ide-base](https://atom.io/packages/atom-ide-base).
 
-- **Linting**
-  - [linter](https://atom.io/packages/linter)
-  - [linter-ui-default](https://atom.io/packages/linter-ui-default)
-- **TypeScript** While not strictly needed for TS support in Svelte components... Well, Svelte components are probably not going to make 100% of your app, and on the TS road, the more the better!
-  - [atom-typescript](https://atom.io/packages/atom-typescript)
-  - [language-typescript](https://atom.io/packages/language-typescript)
-- **Info tooltips**
-  - [atom-ide-datatip](https://atom.io/packages/atom-ide-datatip)
-- **Navigate references/definitions**
-  - [atom-refs](https://atom.io/packages/atom-refs) Still, no endorsment, but I can vouch for the author ^^ (full disclaimer: it's me).
-- **Prettier**
-  - [mprettier](https://atom.io/packages/mprettier) Hard & fast alternative to the official [prettier-atom](https://atom.io/packages/prettier-atom) plugin.
-- **Emmet snippets**
-  - [emmet](https://atom.io/packages/emmet)
+You can use this all-inclusive package and/or pick just what you need. While assuming no endorsement, the following Atom packages have been used with some satisfaction for Svelte development in Atom by some of the authors of this plugin.
+
+#### Autocomplete
+
+- [autocomplete-plus](https://atom.io/packages/autocomplete-plus) (Bundled with Atom)
+
+#### Linting / diagnostic
+
+- [linter](https://atom.io/packages/linter)
+- [linter-ui-default](https://atom.io/packages/linter-ui-default)
+
+#### Datatips
+
+- [atom-ide-datatip](https://atom.io/packages/atom-ide-datatip)
+
+#### Code formatting
+
+The Svelte language server provides formatting capabilities for Svelte components (via internal Prettier). This can be consumed by a formatting package like the following:
+
+- [atom-ide-code-format](https://github.com/atom-community/atom-ide-code-format)
+
+Alternatively, if your project is correctly setup for [Svelte with Prettier](https://github.com/sveltejs/prettier-plugin-svelte), you might prefer to use a Prettier extension for formatting of all your files (`.svelte`, `.js`, `.ts`, etc.):
+
+- [prettier-atom](https://atom.io/packages/prettier-atom) Maintained by Prettier, but has a tendency of freezing my editor with Svelte components
+- [mprettier](https://atom.io/packages/mprettier) A bare alternative that works better for me with Svelte
+
+#### Highlights / navigating references
+
+There doesn't appear to be some established package for code highlights / navigating references in Atom currently, but I have personally been using a hacked together plugin you might have some luck with.
+
+- [atom-refs](https://atom.io/packages/atom-refs) Highlights references, and jump to definition or import, in JS, TS and Svelte. (Also compatible with (atom-ide-hyperclick)[https://atom.io/packages/atom-ide-hyperclick] for mouse support.)


### PR DESCRIPTION
While doing some research about Atom's LSP ecosystem (for #16), I was able to confirm that we do also have working autocomplete and code formatting in the plugin.

As a side note, I'm a bit surprised that the LS doesn't expose code highlight capability... Is that fundamentally different from to getting references? Not that this would make a big difference here, since there's apparently no go-to extension to consume the capability in Atom currently.